### PR TITLE
fix: read response body always

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,20 +1,14 @@
 ---
 linters:
-  enable:
-  - deadcode
-  - goconst
-  - gofmt
-  - goimports
-  - golint
-  - gosimple
-  - govet
-  - interfacer
-  - maligned
-  - misspell
-  - nakedret
-  - staticcheck
-  - structcheck
-  - unconvert
-  - unused
-  - varcheck
-  disable-all: true
+  enable-all: true
+  disable:
+  - wsl
+  - testpackage
+  - godot
+  - goerr113
+  - lll
+  - funlen
+  - gocognit
+  - godox
+  - nestif
+  - gomnd

--- a/go.sum
+++ b/go.sum
@@ -8,9 +8,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/scylladb/go-set v1.0.2/go.mod h1:DkpGd78rljTxKAnTDPFqXSGxvETQnJyuSOQwsHycqfs=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.5.1 h1:nOGnQDM7FYENwehXlg/kFVnos3rEvtKTjRvOWSzb6H4=
-github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/stretchr/testify v1.6.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/suzuki-shunsuke/flute v0.7.0 h1:DvDSCMIMiLlRj4AQPMeJ1NfHE3lG5yfs2LU0Dnf1+oc=
 github.com/suzuki-shunsuke/flute v0.7.0/go.mod h1:UZOMr3GyEuYSr7/zf0nHgaLP9ZhKDB+2pBeV1WFkohE=
@@ -20,6 +18,6 @@ github.com/suzuki-shunsuke/go-jsoneq v0.1.1/go.mod h1:vbOEb6bPf8nD+QASKzxtQ/vfVG
 github.com/suzuki-shunsuke/gomic v0.5.6/go.mod h1:GEDQnxOB07p3mTZG/MiuclfyfcqnNqp0rt9AHgIzs7Q=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/httpclient/client.go
+++ b/httpclient/client.go
@@ -166,6 +166,8 @@ func (client *Client) Call(ctx context.Context, params *CallParams) (*http.Respo
 		if err := json.NewDecoder(res.Body).Decode(params.ResponseBody); err != nil {
 			return res, fmt.Errorf("failed to read a response body as JSON: %w", err)
 		}
+		return res, nil
 	}
+	_, _ = io.Copy(ioutil.Discard, res.Body)
 	return res, nil
 }

--- a/httpclient/client_test.go
+++ b/httpclient/client_test.go
@@ -32,6 +32,7 @@ func TestError_Error(t *testing.T) {
 	}
 
 	for _, d := range data {
+		d := d
 		t.Run(d.title, func(t *testing.T) {
 			require.Equal(t, d.exp, d.err.Error())
 		})
@@ -301,6 +302,7 @@ func TestClient_Call(t *testing.T) {
 		},
 	}
 	for _, d := range data {
+		d := d
 		t.Run(d.title, func(t *testing.T) {
 			client.HTTPClient.Transport = &flute.Transport{
 				T: t,
@@ -312,7 +314,7 @@ func TestClient_Call(t *testing.T) {
 				},
 			}
 
-			_, err := client.Call(ctx, d.params)
+			_, err := client.Call(ctx, d.params) //nolint:bodyclose
 			if d.isErr {
 				require.NotNil(t, err)
 			} else {


### PR DESCRIPTION
https://golang.org/pkg/net/http/#Response

> The default HTTP client's Transport may not reuse HTTP/1.x "keep-alive" TCP connections
> if the Body is not read to completion and closed.